### PR TITLE
OperatorId can be empty and shouldn't be sent

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     },
     "require-dev": {
         "phpstan/phpstan": "^0.12.42",
-        "phpunit/phpunit": "^9.3"
+        "phpunit/phpunit": "^9.3",
+        "ext-mbstring": "*"
     },
     "suggest": {
         "ext-soap": "Required to use native SOAP client connection."

--- a/src/Traits/Authorizeable.php
+++ b/src/Traits/Authorizeable.php
@@ -175,12 +175,14 @@ trait Authorizeable
                     'auth:stringValue' => $this->getOperatorType(),
                 ],
             ];
-            $credentials[] = [
-                'auth:name'  => $this->operatorIdentificatorKey(),
-                'auth:value' => [
-                    'auth:stringValue' => $this->getOperatorIdentificator(),
-                ],
-            ];
+            if ($this->getOperatorIdentificator()) {
+                $credentials[] = [
+                    'auth:name'  => $this->operatorIdentificatorKey(),
+                    'auth:value' => [
+                        'auth:stringValue' => $this->getOperatorIdentificator(),
+                    ],
+                ];
+            }
         }
 
         return $credentials;

--- a/tests/Feature/LoginTest.php
+++ b/tests/Feature/LoginTest.php
@@ -45,6 +45,24 @@ class LoginTest extends TestCase
         $this->assertSame(22, mb_strlen($response->getToken() ?? ''));
     }
 
+    public function testLoginLek(): void
+    {
+        $request = new LoginRequest();
+        $request->setDomain('01');
+        $request->setLogin('TEST');
+        $request->setPassword('qwerty!@#');
+        $request->setOperatorId('');
+        $request->setOperatorType(OperatorType::DOCTOR);
+
+        /** @var \NGT\Ewus\Responses\LoginResponse */
+        $response = $this->handler->handle($request);
+
+        $this->assertSame('000', $response->getLoginCode());
+        $this->assertSame('Użytkownik został prawidłowo zalogowany.', $response->getLoginMessage());
+        $this->assertSame(32, mb_strlen($response->getSessionId() ?? ''));
+        $this->assertSame(22, mb_strlen($response->getToken() ?? ''));
+    }
+
     public function testLoginWithInvalidData(): void
     {
         $this->expectException(ResponseException::class);


### PR DESCRIPTION
Hi.
This fix allows use (test) LEK operator type.
OperatorId can be empty.  But empty string shouldn't be sent.
Test works successfully with NFZ test account (for 01 LEK).